### PR TITLE
fix a bug

### DIFF
--- a/FastBleLib/src/main/java/com/clj/fastble/BleManager.java
+++ b/FastBleLib/src/main/java/com/clj/fastble/BleManager.java
@@ -370,6 +370,15 @@ public class BleManager {
      * @return
      */
     public BluetoothGatt connect(String mac, BleGattCallback bleGattCallback) {
+        // check the mac address before calling getRemoteDevice() to avoid
+        // exception throwed by the method getRemoteDevice()
+        boolean isValid = BluetoothAdapter.checkBluetoothAddress(mac);
+        if(!isValid){
+            BleLog.e("mac address is invalid");
+            bleGattCallback.onConnectFail(null, new OtherException("mac address is invalid"));
+            return null;
+        }
+
         BluetoothDevice bluetoothDevice = getBluetoothAdapter().getRemoteDevice(mac);
         BleDevice bleDevice = new BleDevice(bluetoothDevice, 0, null, 0);
         return connect(bleDevice, bleGattCallback);


### PR DESCRIPTION
   before calling _getRemoteDevice(address)_, we have to check if the mac address is valid, because _getRemoteDevice(address)_ would throw an exception if the address is invalid.
   BTY, i noticed that two methods _enableBluetooth()/disableBluetooth()_ in BleManager class, there may be some problems if use this two methods to open or close bluetooth, because after calling **bluetoothAdapter.**_enable()/disable()_, some cellphones will show users a dialog to request  for opening or closing bluetooth, which will make the result uncertain.
