### PR TITLE
修复停止扫描后内存泄漏

### DIFF
--- a/FastBleLib/src/main/java/com/clj/fastble/scan/BleScanPresenter.java
+++ b/FastBleLib/src/main/java/com/clj/fastble/scan/BleScanPresenter.java
@@ -210,6 +210,8 @@ public abstract class BleScanPresenter implements BluetoothAdapter.LeScanCallbac
             @Override
             public void run() {
                 onScanFinished(mBleDeviceList);
+                //czh add  修复stopScan之后内存泄漏问题！外部如果使用匿名类设置的监听引起的内存泄漏
+                mBleScanPresenterImp=null;
             }
         });
     }


### PR DESCRIPTION
如果外部扫描通过匿名类设置监听后，停止扫描后对象无法自动释放，
因为匿名类默认持有外部activity对象，然后单例持有匿名类形成循环引用，导致activity退出后无法gc